### PR TITLE
Feat: Code Reviews

### DIFF
--- a/OUTPUT.md
+++ b/OUTPUT.md
@@ -6,6 +6,8 @@ Opened **80** issues
 
 Submitted **115** pull requests
 
+Reviewed **75** pull requests
+
 Received **254** stars
 
 Own **13** repositories

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This action provides [template strings](#template-strings) that are replaced wit
       - [`{{ ACCOUNT_AGE }}`](#-account_age-)
       - [`{{ ISSUES }}`](#-issues-)
       - [`{{ PULL_REQUESTS }}`](#-pull_requests-)
+      - [`{{ CODE_REVIEWS }}`](#-code_reviews-)
       - [`{{ COMMITS }}`](#-commits-)
       - [`{{ GISTS }}`](#-gists-)
       - [`{{ REPOSITORIES }}`](#-repositories-)
@@ -77,6 +78,10 @@ Total number of opened issues across all repositories.
 #### `{{ PULL_REQUESTS }}`
 
 Total number of opened pull requests across all repositories.
+
+#### `{{ CODE_REVIEWS }}`
+
+Total number of pull requests reviewed across all repositories.
 
 #### `{{ COMMITS }}`
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -6,6 +6,8 @@ Opened **{{ ISSUES }}** issues
 
 Submitted **{{ PULL_REQUESTS }}** pull requests
 
+Reviewed **{{ CODE_REVIEWS }}** pull requests
+
 Received **{{ STARS }}** stars
 
 Own **{{ REPOSITORIES }}** repositories


### PR DESCRIPTION
Resolves https://github.com/teoxoy/profile-readme-stats/issues/9.

Details per commit:

1. To keep things separate and simple, imitate the implementation of `getTotalCommits` for `getTotalReviews`.
2. I let yarn update the `dist/index.js` -
```console
yarn format:fix && yarn build
```
3. Update README, TEMPLATE and OUTPUT to include `{{ CODE_REVIEWS }}`

I'm not entirely sure how to test it out locally, but GitHub [API Explorer](https://docs.github.com/en/graphql/overview/explorer) seems to be happy with the query.