### PR TITLE
Issue number retrieval by state

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,10 @@ async function getUserInfo(gql: typeof graphql, includeForks = false) {
     const query = `{
         viewer {
             createdAt
-            issues {
+            openIssues: issues(states: OPEN) {
+                totalCount
+            }
+            closedIssues: issues(states: CLOSED) {
                 totalCount
             }
             pullRequests {
@@ -133,7 +136,10 @@ async function getUserInfo(gql: typeof graphql, includeForks = false) {
     interface Result {
         viewer: {
             createdAt: string
-            issues: {
+            openIssues: {
+                totalCount: number
+            }
+            closedIssues: {
                 totalCount: number
             }
             pullRequests: {
@@ -159,7 +165,8 @@ async function getUserInfo(gql: typeof graphql, includeForks = false) {
     const {
         viewer: {
             createdAt,
-            issues,
+            openIssues,
+            closedIssues,
             pullRequests,
             contributionsCollection: { contributionYears },
             gists,
@@ -177,7 +184,7 @@ async function getUserInfo(gql: typeof graphql, includeForks = false) {
 
     return {
         accountAge,
-        issues: issues.totalCount,
+        issues: openIssues.totalCount + closedIssues.totalCount,
         pullRequests: pullRequests.totalCount,
         contributionYears,
         gists: gists.totalCount,


### PR DESCRIPTION
This change splits the retrieval of the number of issues into two parts:

1. the retrieval of all open issues
2. the retrieval of all closed issues

The sum of both numbers is now returned as the total number of issues.

Fixes #17 